### PR TITLE
Fix Rheintal and Toponym nouns in list_nouns.txt

### DIFF
--- a/app/src/main/res/raw/list_nouns.txt
+++ b/app/src/main/res/raw/list_nouns.txt
@@ -2658,7 +2658,8 @@ Mitbürger,m
 Donnerstagabend,m
 Model,n
 Spender,m
-Rheintal,Toponym
+Rheintal,n
+Toponym,n
 Aids,n
 Neuling,m
 Geschick,n


### PR DESCRIPTION
There is an error in the text file, why do you have a few reviews that note that in Google Play. App crashes because of that